### PR TITLE
Provide multicolored support for multiple sports

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Run on webpack dev web server
 
 ```javascript
 $ webpack-dev-server --progress --colors
+```
 
 
 ## Strava

--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ night.
 
 http://library.nothingness.org/articles/SI/en/display/314
 
+
+## Get Started
+
+Install dependencies
+
+```javascript
+$ npm install 
+```
+ Build bundle
+ 
+ ```javascript
+$ webpack
+ ```
+
+Run on webpack dev web server
+
+```javascript
+$ webpack-dev-server --progress --colors
+
+
 ## Strava
 
 If you use Strava, go to

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 
     <script src="bundle.js"></script>
-    <title>dérive.</title>
+    <title>d&eacute;rive.</title>
 </head>
 
 <body>

--- a/src/app.js
+++ b/src/app.js
@@ -1,12 +1,12 @@
-import '../style.css'
+import '../style.css';
 
-import GpxMap from './map'
-import {initialize} from './ui'
+import GpxMap from './map';
+import {initialize} from './ui';
 
 
 function app() {
-    let map = new GpxMap()
-    initialize(map)
+    let map = new GpxMap();
+    initialize(map);
 }
 
 
@@ -16,11 +16,11 @@ function app() {
 // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#Polyfill
 if (!HTMLCanvasElement.prototype.toBlob) {
     Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
-        value: function (callback, type, quality) {
+        value (callback, type, quality) {
 
-            var binStr = atob(this.toDataURL(type, quality).split(',')[1]),
-                len = binStr.length,
-                arr = new Uint8Array(len);
+            let binStr = atob(this.toDataURL(type, quality).split(',')[1]);
+            let len = binStr.length;
+            let arr = new Uint8Array(len);
 
             for (var i = 0; i < len; i++ ) {
                 arr[i] = binStr.charCodeAt(i);
@@ -32,4 +32,4 @@ if (!HTMLCanvasElement.prototype.toBlob) {
 }
 
 
-document.addEventListener('DOMContentLoaded', app)
+document.addEventListener('DOMContentLoaded', app);

--- a/src/gpx.js
+++ b/src/gpx.js
@@ -2,16 +2,16 @@
 //
 // https://github.com/taterbase/gpx-parser
 
-import xml2js from 'xml2js'
+import xml2js from 'xml2js';
 
 
-const parser = new xml2js.Parser()
+const parser = new xml2js.Parser();
 
 
 function extractTrack(gpx) {
     if (!gpx.trk || gpx.trk.length !== 1 || gpx.trk[0].trkseg.length !== 1) {
-        console.log('Wild assumptions failed: trk.length = 1', gpx.trk)
-        throw new Error('Unexpected gpx file format.')
+        console.log('Wild assumptions failed: trk.length = 1', gpx.trk);
+        throw new Error('Unexpected gpx file format.');
     }
 
     let points = gpx.trk[0].trkseg[0].trkpt.map(trkpt => ({
@@ -31,13 +31,13 @@ function extractTrack(gpx) {
 
 export default function parseGPX(gpxString, cb) {
     return parser.parseString(gpxString, (err, result) => {
-        if (err) return cb(err)
-        if (!result.gpx) return cb(new Error("Invalid file type."))
+        if (err) return cb(err);
+        if (!result.gpx) return cb(new Error("Invalid file type."));
 
         try {
-            return cb(null, extractTrack(result.gpx))
+            return cb(null, extractTrack(result.gpx));
         } catch (e) {
-            return cb(e, null)
+            return cb(e, null);
         }
     })
 }

--- a/src/map.js
+++ b/src/map.js
@@ -83,17 +83,18 @@ export default class GpxMap {
 
         let centre = this.centre.bind(this);
 
-        leaflet.easyButton({
+        this.viewAll = leaflet.easyButton({
             type: 'animate',
             states: [{
-                icon: 'fa-crosshairs fa-lg',
+                icon: 'fa-map fa-lg',
                 stateName: 'default',
-                title: 'Centre map on tracks',
+                title: 'Zoom to all tracks',
                 onClick: (_btn, map) => {
                     centre();
                 },
             }],
         }).addTo(this.map);
+        this.viewAll.disable();
 
         this.switchTheme(this.options.theme);
         this.requestBrowserLocation();
@@ -147,6 +148,7 @@ export default class GpxMap {
 
     addTrack(track) {
         let line = leaflet.polyline(track, this.options.lineOptions);
+        this.viewAll.enable();
         line.addTo(this.map);
 
         this.tracks.push(line);

--- a/src/map.js
+++ b/src/map.js
@@ -150,7 +150,7 @@ export default class GpxMap {
     addTrack(track) {
         this.viewAll.enable();
         let lineOptions = Object.assign({}, this.options.lineOptions);
-        if (lineOptions.detect) {
+        if (lineOptions.detectColors) {
             if (/-(Hike|Walk)\.gpx/.test(track.filename))
                 lineOptions.color = "pink";
             else if (/-Run\.gpx/.test(track.filename))

--- a/src/map.js
+++ b/src/map.js
@@ -82,7 +82,7 @@ export default class GpxMap {
             }],
         }).addTo(this.map);
 
-        let centre = this.centre.bind(this);
+        let center = this.center.bind(this);
 
         this.viewAll = leaflet.easyButton({
             type: 'animate',
@@ -91,7 +91,7 @@ export default class GpxMap {
                 stateName: 'default',
                 title: 'Zoom to all tracks',
                 onClick: (_btn, map) => {
-                    centre();
+                    center();
                 },
             }],
         }).addTo(this.map);
@@ -165,10 +165,10 @@ export default class GpxMap {
         this.tracks.push(line);
 
         if (!this.scrolled)
-            this.centre();
+            this.center();
     }
 
-    centre() {
+    center() {
         let scrolled = this.scrolled;
         this.map.fitBounds((new L.featureGroup(this.tracks)).getBounds(), {
             noMoveStart: true,

--- a/src/map.js
+++ b/src/map.js
@@ -17,6 +17,7 @@ const DEFAULT_OPTIONS = {
         weight: 1,
         opacity: 0.5,
         smoothFactor: 1,
+        existing: true,
     }
 };
 
@@ -114,16 +115,18 @@ export default class GpxMap {
         if (opts.theme !== this.options.theme) {
             this.switchTheme(opts.theme);
         }
+        
+        if (opts.lineOptions.existing) {
+            this.tracks.forEach(t => {
+                t.setStyle({
+                    color: opts.lineOptions.color,
+                    weight: opts.lineOptions.weight,
+                    opacity: opts.lineOptions.opacity,
+                });
 
-        this.tracks.forEach(t => {
-            t.setStyle({
-                color: opts.lineOptions.color,
-                weight: opts.lineOptions.weight,
-                opacity: opts.lineOptions.opacity,
+                t.redraw();
             });
-
-            t.redraw();
-        });
+        }
 
         this.options = opts;
     }

--- a/src/map.js
+++ b/src/map.js
@@ -75,7 +75,7 @@ export default class GpxMap {
                 stateName: 'default',
                 title: 'Open settings dialog',
                 onClick: (_btn, map) => {
-                    buildSettingsModal(this.options, (opts) => {
+                    buildSettingsModal(this, this.options, (opts) => {
                         this.updateOptions(opts)
                     }).show();
                 },
@@ -152,11 +152,11 @@ export default class GpxMap {
         let lineOptions = Object.assign({}, this.options.lineOptions);
         if (lineOptions.detectColors) {
             if (/-(Hike|Walk)\.gpx/.test(track.filename))
-                lineOptions.color = "pink";
+                lineOptions.color = "#ffc0cb";
             else if (/-Run\.gpx/.test(track.filename))
-                lineOptions.color = "red";
+                lineOptions.color = "#ff0000";
             else if (/-Ride\.gpx/.test(track.filename))
-                lineOptions.color = "cyan";
+                lineOptions.color = "#00ffff";
         }
         let line = leaflet.polyline(track.points, lineOptions);
         line.addTo(this.map);

--- a/src/map.js
+++ b/src/map.js
@@ -18,6 +18,7 @@ const DEFAULT_OPTIONS = {
         opacity: 0.5,
         smoothFactor: 1,
         existing: true,
+        detectColors: true,
     }
 };
 
@@ -147,8 +148,17 @@ export default class GpxMap {
     }
 
     addTrack(track) {
-        let line = leaflet.polyline(track, this.options.lineOptions);
         this.viewAll.enable();
+        let lineOptions = Object.assign({}, this.options.lineOptions);
+        if (lineOptions.detect) {
+            if (/-(Hike|Walk)\.gpx/.test(track.filename))
+                lineOptions.color = "pink";
+            else if (/-Run\.gpx/.test(track.filename))
+                lineOptions.color = "red";
+            else if (/-Ride\.gpx/.test(track.filename))
+                lineOptions.color = "cyan";
+        }
+        let line = leaflet.polyline(track.points, lineOptions);
         line.addTo(this.map);
 
         this.tracks.push(line);

--- a/src/map.js
+++ b/src/map.js
@@ -107,7 +107,8 @@ export default class GpxMap {
     }
 
     switchTheme(themeName) {
-        if (this.mapTiles) this.mapTiles.removeFrom(this.map);
+        if (this.mapTiles)
+            this.mapTiles.removeFrom(this.map);
 
         this.mapTiles = leaflet.tileLayer.provider(themeName);
         this.mapTiles.addTo(this.map, {detectRetina: true});
@@ -163,7 +164,8 @@ export default class GpxMap {
 
         this.tracks.push(line);
 
-        if (!this.scrolled) this.centre();
+        if (!this.scrolled)
+            this.centre();
     }
 
     centre() {
@@ -172,12 +174,14 @@ export default class GpxMap {
             noMoveStart: true,
             padding: [50,20],
         });
-        if (!scrolled) this.clearScroll();
+        if (!scrolled)
+            this.clearScroll();
     }
 
     screenshot(format, domNode) {
         leafletImage(this.map, (err, canvas) => {
-            if (err) return window.alert(err);
+            if (err)
+                return window.alert(err);
 
             let anchor = document.createElement('a');
 

--- a/src/map.js
+++ b/src/map.js
@@ -82,8 +82,6 @@ export default class GpxMap {
             }],
         }).addTo(this.map);
 
-        let center = this.center.bind(this);
-
         this.viewAll = leaflet.easyButton({
             type: 'animate',
             states: [{
@@ -91,7 +89,7 @@ export default class GpxMap {
                 stateName: 'default',
                 title: 'Zoom to all tracks',
                 onClick: (_btn, map) => {
-                    center();
+                    this.center();
                 },
             }],
         }).addTo(this.map);

--- a/src/map.js
+++ b/src/map.js
@@ -75,7 +75,7 @@ export default class GpxMap {
                 stateName: 'default',
                 title: 'Open settings dialog',
                 onClick: (_btn, map) => {
-                    buildSettingsModal(this, this.options, (opts) => {
+                    buildSettingsModal(this.tracks, this.options, (opts) => {
                         this.updateOptions(opts)
                     }).show();
                 },

--- a/src/map.js
+++ b/src/map.js
@@ -1,13 +1,13 @@
-import leaflet from 'leaflet'
-import leafletImage from 'leaflet-image'
-import 'leaflet-providers'
-import 'leaflet-easybutton'
+import leaflet from 'leaflet';
+import leafletImage from 'leaflet-image';
+import 'leaflet-providers';
+import 'leaflet-easybutton';
 
-import {buildSettingsModal, showModal} from  './ui'
+import {buildSettingsModal, showModal} from  './ui';
 
 
 // Los Angeles is the center of the universe
-const INIT_COORDS = [34.0522, -118.243]
+const INIT_COORDS = [34.0522, -118.243];
 
 
 const DEFAULT_OPTIONS = {
@@ -16,21 +16,21 @@ const DEFAULT_OPTIONS = {
         color: '#0CB1E8',
         weight: 1,
         opacity: 0.5,
-        smoothFactor: 1
+        smoothFactor: 1,
     }
-}
+};
 
 
 export default class GpxMap {
     constructor(options) {
-        this.options = options || DEFAULT_OPTIONS
-        this.tracks = []
+        this.options = options || DEFAULT_OPTIONS;
+        this.tracks = [];
 
         this.map = leaflet.map('background-map', {
             center: INIT_COORDS,
             zoom: 10,
-            preferCanvas: true
-        })
+            preferCanvas: true,
+        });
 
         leaflet.easyButton({
             type: 'animate',
@@ -39,21 +39,21 @@ export default class GpxMap {
                 stateName: 'default',
                 title: 'Export as png',
                 onClick: (_btn, map) => {
-                    let modal = showModal('export')
+                    let modal = showModal('exportImage')
                             .afterClose(() => modal.destroy())
 
                     document.getElementById('render-export').onclick = (e) => {
-                        e.preventDefault()
+                        e.preventDefault();
 
-                        let resultNode = document.createElement('li')
-                        let container = document.getElementById('export-list')
+                        let resultNode = document.createElement('li');
+                        let container = document.getElementById('export-list');
 
-                        resultNode.innerText = '... rendering ...'
-                        container.innerText = ''
-                        container.appendChild(resultNode)
+                        resultNode.innerText = '... rendering ...';
+                        container.innerText = '';
+                        container.appendChild(resultNode);
 
-                        let elements = document.getElementById('settings').elements
-                        this.screenshot(elements.format.value, resultNode)
+                        let elements = document.getElementById('settings').elements;
+                        this.screenshot(elements.format.value, resultNode);
                     }
                 }
             }]
@@ -68,79 +68,78 @@ export default class GpxMap {
                 onClick: (_btn, map) => {
                     buildSettingsModal(this.options, (opts) => {
                         this.updateOptions(opts)
-                    }).show()
-                }
-            }]
-        }).addTo(this.map)
+                    }).show();
+                },
+            }],
+        }).addTo(this.map);
 
-        this.switchTheme(this.options.theme)
-        this.requestBrowserLocation()
+        this.switchTheme(this.options.theme);
+        this.requestBrowserLocation();
     }
 
     switchTheme(themeName) {
-        if (this.mapTiles)
-            this.mapTiles.removeFrom(this.map)
+        if (this.mapTiles) this.mapTiles.removeFrom(this.map);
 
-        this.mapTiles = leaflet.tileLayer.provider(themeName)
-        this.mapTiles.addTo(this.map, {detectRetina: true})
+        this.mapTiles = leaflet.tileLayer.provider(themeName);
+        this.mapTiles.addTo(this.map, {detectRetina: true});
     }
 
     updateOptions(opts) {
         if (opts.theme !== this.options.theme) {
-            this.switchTheme(opts.theme)
+            this.switchTheme(opts.theme);
         }
 
         this.tracks.forEach(t => {
             t.setStyle({
                 color: opts.lineOptions.color,
                 weight: opts.lineOptions.weight,
-                opacity: opts.lineOptions.opacity
-            })
+                opacity: opts.lineOptions.opacity,
+            });
 
-            t.redraw()
-        })
+            t.redraw();
+        });
 
-        this.options = opts
+        this.options = opts;
     }
 
     // Try to pull geo location from browser and center the map
     requestBrowserLocation() {
-        navigator.geolocation.getCurrentPosition((pos) => {
-            this.map.panTo([pos.coords.latitude, pos.coords.longitude])
-        })
+        navigator.geolocation.getCurrentPosition(pos => {
+            this.map.panTo([pos.coords.latitude, pos.coords.longitude]);
+        });
     }
 
     addTrack(track) {
-        let line = leaflet.polyline(track, this.options.lineOptions)
-        line.addTo(this.map)
+        let line = leaflet.polyline(track, this.options.lineOptions);
+        line.addTo(this.map);
 
-        this.tracks.push(line)
+        this.tracks.push(line);
     }
 
     screenshot(format, domNode) {
         leafletImage(this.map, (err, canvas) => {
-            if (err) return window.alert(err)
+            if (err) return window.alert(err);
 
-            let anchor = document.createElement('a')
+            let anchor = document.createElement('a');
 
             if (format == 'png') {
-                anchor.download = 'derive-export.png'
-                anchor.innerText = 'Download as PNG'
+                anchor.download = 'derive-export.png';
+                anchor.innerText = 'Download as PNG';
 
                 canvas.toBlob(blob => {
-                    anchor.href = URL.createObjectURL(blob)
-                    domNode.innerHTML = anchor.outerHTML
+                    anchor.href = URL.createObjectURL(blob);
+                    domNode.innerHTML = anchor.outerHTML;
                 })
             } else if (format == 'svg') {
-                anchor.innerText = 'Download as SVG'
+                anchor.innerText = 'Download as SVG';
 
-                let origin = this.map.getBounds(),
-                    top = origin.getNorthWest(),
-                    bot = origin.getSouthEast()
+                let origin = this.map.getBounds();
+                let top = origin.getNorthWest();
+                let bot = origin.getSouthEast();
 
-                const width = bot.lng - top.lng,
-                      height = top.lat - bot.lat,
-                      scale = 1000
+                const width = bot.lng - top.lng;
+                const height = top.lat - bot.lat;
+                const scale = 1000;
 
                 let paths = this.tracks
                     .map(trk => trk.getLatLngs())
@@ -148,17 +147,17 @@ export default class GpxMap {
                         x: (c.lng - top.lng) * scale,
                         y: (top.lat - c.lat) * scale
                     })))
-                    .map(pts => leaflet.SVG.pointsToPath([pts], false))
+                    .map(pts => leaflet.SVG.pointsToPath([pts], false));
 
-                let svg = leaflet.SVG.create('svg')
-                let root = leaflet.SVG.create('g')
+                let svg = leaflet.SVG.create('svg');
+                let root = leaflet.SVG.create('g');
 
-                svg.setAttribute('viewBox', `0 0 ${scale * width} ${scale * height}`)
+                svg.setAttribute('viewBox', `0 0 ${scale * width} ${scale * height}`);
 
-                let opts = this.options.lineOptions
+                let opts = this.options.lineOptions;
 
                 paths.forEach(path => {
-                    let el = leaflet.SVG.create('path')
+                    let el = leaflet.SVG.create('path');
 
                     el.setAttribute('stroke', opts.color);
                     el.setAttribute('stroke-opacity', opts.opacity);
@@ -167,21 +166,21 @@ export default class GpxMap {
                     el.setAttribute('stroke-linejoin', 'round');
                     el.setAttribute('fill', 'none');
 
-                    el.setAttribute('d', path)
+                    el.setAttribute('d', path);
 
-                    root.appendChild(el)
-                })
+                    root.appendChild(el);
+                });
 
-                svg.appendChild(root)
+                svg.appendChild(root);
 
-                let xml = (new XMLSerializer()).serializeToString(svg)
-                anchor.download = 'derive-export.svg'
+                let xml = (new XMLSerializer()).serializeToString(svg);
+                anchor.download = 'derive-export.svg';
 
-                let blob = new Blob([xml], {type: 'application/octet-stream'})
-                anchor.href = URL.createObjectURL(blob)
+                let blob = new Blob([xml], {type: 'application/octet-stream'});
+                anchor.href = URL.createObjectURL(blob);
 
-                domNode.innerHTML = anchor.outerHTML
+                domNode.innerHTML = anchor.outerHTML;
             }
-        })
+        });
     }
 }

--- a/src/map.js
+++ b/src/map.js
@@ -17,7 +17,7 @@ const DEFAULT_OPTIONS = {
         weight: 1,
         opacity: 0.5,
         smoothFactor: 1,
-        existing: true,
+        overrideExisting: true,
         detectColors: true,
     }
 };
@@ -118,7 +118,7 @@ export default class GpxMap {
             this.switchTheme(opts.theme);
         }
         
-        if (opts.lineOptions.existing) {
+        if (opts.lineOptions.overrideExisting) {
             this.tracks.forEach(t => {
                 t.setStyle({
                     color: opts.lineOptions.color,

--- a/src/ui.js
+++ b/src/ui.js
@@ -139,13 +139,13 @@ function buildUploadModal(numFiles) {
 }
 
 
-export function buildSettingsModal(map, opts, finishCallback) {
+export function buildSettingsModal(tracks, opts, finishCallback) {
     let overrideExisting = opts.lineOptions.overrideExisting ? 'checked' : '';
-    let allSameColor = map.tracks.every(val => (
-        val.options.color === map.tracks[0].options.color));
-    if (map.tracks.length > 0 && !allSameColor) overrideExisting = false;
-    else if (map.tracks.length > 0 && allSameColor) {
-        opts.lineOptions.color = map.tracks[0].options.color;
+    let allSameColor = tracks.every(val => (
+        val.options.color === tracks[0].options.color));
+    if (mtracks.length > 0 && !allSameColor) overrideExisting = false;
+    else if (tracks.length > 0 && allSameColor) {
+        opts.lineOptions.color = tracks[0].options.color;
     }
     let detect = opts.lineOptions.detectColors ? 'checked' : '';
     let themes = AVAILABLE_THEMES.map(t => {

--- a/src/ui.js
+++ b/src/ui.js
@@ -90,6 +90,7 @@ function handleFileSelect(map, evt) {
         if (err) {
             parseFailures.push({name: file.name, error: err});
         } else {
+            track.filename = file.name;
             tracks.push(track);
         }
     
@@ -139,9 +140,10 @@ function buildUploadModal(numFiles) {
 
 
 export function buildSettingsModal(opts, finishCallback) {
+    let existing = opts.lineOptions.existing ? 'checked' : '';
+    let detect = opts.lineOptions.detectColors ? 'checked' : '';
     let themes = AVAILABLE_THEMES.map(t => {
         let selected = t == opts.theme ? 'selected' : '';
-        let existing = opts.lineOptions.existing ? 'checked' : '';
 
         return `<option ${selected} value="${t}">${t}</option>`;
     })
@@ -176,7 +178,12 @@ export function buildSettingsModal(opts, finishCallback) {
 
     <span class="form-row">
         <label>Apply to existing</label>
-        <input name="existing" type="checkbox" ${checked}>
+        <input name="existing" type="checkbox" ${existing}>
+    </span>
+
+    <span class="form-row">
+        <label>Detect color from Strava bulk export</label>
+        <input name="detect" type="checkbox" ${detect}>
     </span>
 </form>
 `;
@@ -203,7 +210,7 @@ export function buildSettingsModal(opts, finishCallback) {
             options.lineOptions[opt] = elements[opt].value;
         }
 
-        for (let opt of ['existing']) {
+        for (let opt of ['existing', 'detect']) {
             options.lineOptions[opt] = elements[opt].checked;
         }
         

--- a/src/ui.js
+++ b/src/ui.js
@@ -15,10 +15,11 @@ const AVAILABLE_THEMES = [
     'Stamen.TonerLite',
     'Stamen.TonerBackground',
     'Stamen.Watercolor',
-]
+];
 
 const MODAL_CONTENT = {
-    help: `<h1>dérive</h1>
+    help: `
+<h1>dérive</h1>
 <h4>Drag and drop one or more GPX files here</h4>
 <p>If you use Strava, you can obtain a ZIP file of your activity data
 in GPX format on your <a href="https://www.strava.com/settings/profile">profile
@@ -40,26 +41,26 @@ the attractions of the terrain and the encounters they find there.
 <p>Code is available <a href="https://github.com/erik/derive">on GitHub</a>.</p>
 `,
 
-    export: `
+    exportImage: `
 <h3>Export Image</h3>
 
 <form id="settings">
-  <div class="form-row">
-    <label>Format:</label>
-    <select name="format">
-      <option selected value="png">PNG</option>
-      <option value="svg">SVG (no background map)</option>
-    </select>
-  </div>
+    <div class="form-row">
+        <label>Format:</label>
+        <select name="format">
+            <option selected value="png">PNG</option>
+            <option value="svg">SVG (no background map)</option>
+        </select>
+    </div>
 
-  <div class="form-row">
-    <label></label>
-    <input id="render-export" type="button" value="Render">
-  </div>
+    <div class="form-row">
+        <label></label>
+        <input id="render-export" type="button" value="Render">
+    </div>
 </form>
 
 <div id="export-container">
-  <ul id="export-list"></ul>
+    <ul id="export-list"></ul>
 </div>
 `
 }
@@ -67,173 +68,183 @@ the attractions of the terrain and the encounters they find there.
 
 // Adapted from: http://www.html5rocks.com/en/tutorials/file/dndfiles/
 function handleFileSelect(map, evt) {
-    evt.stopPropagation()
-    evt.preventDefault()
+    evt.stopPropagation();
+    evt.preventDefault();
 
-    let tracks = []
-    let files = evt.dataTransfer.files
-    let modal = buildUploadModal(files.length)
+    let tracks = [];
+    let files = evt.dataTransfer.files;
+    let modal = buildUploadModal(files.length);
 
-    modal.show()
+    modal.show();
 
-    let fileIndex = 0
-    let parseFailures = []
+    let fileIndex = 0;
+    let parseFailures = [];
 
     function loadNextFile() {
         if (fileIndex >= files.length) {
             tracks.forEach(t => {
-                console.log('Adding track:', t.name)
-                map.addTrack(t.points)
-            })
+                console.log('Adding track:', t.name);
+                map.addTrack(t.points);
+            });
 
             if (parseFailures.length > 0) {
-                console.error('Failed files:', parseFailures)
-                window.alert(`Finished loading with ${parseFailures.length} failure(s)\n
-View console for info.`)
+                console.error('Failed files:', parseFailures);
+                alert(`Finished loading with ${parseFailures.length} failure(s)\n
+View console for info.`);
             }
 
-            return modal.destroy()
+            return modal.destroy();
         }
 
-        let reader = new FileReader()
+        let reader = new FileReader();
         reader.onload = (event) => {
             parseGPX(event.target.result, (err, track) => {
                 // TODO: Make an error modal
                 if (err) {
-                    let file = files[fileIndex - 1]
-                    parseFailures.push({name: file.name, error: err})
+                    let file = files[fileIndex - 1];
+                    parseFailures.push({name: file.name, error: err});
                 } else {
-                    tracks.push(track)
+                    tracks.push(track);
                 }
 
-                modal.progress(fileIndex)
+                modal.progress(fileIndex);
 
                 // do the next file, but give the UI time to update.
-                window.setTimeout(loadNextFile, 1)
+                setTimeout(loadNextFile, 1);
             })
         }
 
-        reader.readAsBinaryString(files[fileIndex++])
+        reader.readAsBinaryString(files[fileIndex++]);
     }
 
-    loadNextFile()
+    loadNextFile();
 }
 
 
 function handleDragOver(evt) {
-    evt.dataTransfer.dropEffect = 'copy'
-    evt.stopPropagation()
-    evt.preventDefault()
+    evt.dataTransfer.dropEffect = 'copy';
+    evt.stopPropagation();
+    evt.preventDefault();
 }
 
 
 function buildUploadModal(numFiles) {
-    function getModalContent(numLoaded) {
-        return `<h1>Reading GPX files...</h1>
-<span id="">${numLoaded} loaded of <b>${numFiles}</b>`
-    }
+    let getModalContent = numLoaded => `<h1>Reading GPX files...</h1>
+<span id="">${numLoaded} loaded of <b>${numFiles}</b>`;
 
     let modal = picoModal({
         content: getModalContent(0),
         closeButton: false,
         escCloses: false,
         overlayClose: false,
-        overlayStyles: (styles) => { styles.opacity = 0.1 }
+        overlayStyles: styles => {
+            styles.opacity = 0.1;
+        },
     })
 
-    modal.progress = (loaded) => {
-        modal.modalElem().innerHTML = getModalContent(loaded)
-    }
+    modal.progress = loaded => {
+        modal.modalElem().innerHTML = getModalContent(loaded);
+    };
 
-    return modal
+    return modal;
 }
 
 
 export function buildSettingsModal(opts, finishCallback) {
     let themes = AVAILABLE_THEMES.map(t => {
-        let selected = t == opts.theme ? 'selected' : ''
+        let selected = t == opts.theme ? 'selected' : '';
+        let existing = opts.lineOptions.existing ? 'checked' : '';
 
-        return `<option ${selected} value="${t}">${t}</option>`
+        return `<option ${selected} value="${t}">${t}</option>`;
     })
 
     let modalContent = `
 <h3>Options</h3>
 
 <form id="settings">
-  <span class="form-row">
-    <label>Theme</label>
-    <select name="theme">
-       ${themes}
-    </select>
-  </span>
+    <span class="form-row">
+        <label>Theme</label>
+        <select name="theme">
+            ${themes}
+        </select>
+    </span>
 
-  <span class="form-row">
-    <label>Line color</label>
-    <input name="color" type="color" value=${opts.lineOptions.color}>
-  </span>
+    <span class="form-row">
+        <label>Line color</label>
+        <input name="color" type="color" value=${opts.lineOptions.color}>
+    </span>
 
-  <span class="form-row">
-    <label>Line opacity</label>
-    <input name="opacity" type="range" min=0 max=1 step=0.01
-           value=${opts.lineOptions.opacity}>
-  </span>
+    <span class="form-row">
+        <label>Line opacity</label>
+        <input name="opacity" type="range" min=0 max=1 step=0.01
+            value=${opts.lineOptions.opacity}>
+    </span>
 
-  <span class="form-row">
-    <label>Line width</label>
-    <input name="weight" type="number" min=1 max=100
-           value=${opts.lineOptions.weight}>
-  </span>
+    <span class="form-row">
+        <label>Line width</label>
+        <input name="weight" type="number" min=1 max=100
+            value=${opts.lineOptions.weight}>
+    </span>
 </form>
-`
+`;
+
     let modal = picoModal({
         content: modalContent,
         closeButton: true,
         escCloses: true,
         overlayClose: true,
-        overlayStyles: (styles) => { styles.opacity = 0.1 }
-    })
+        overlayStyles: (styles) => {
+            styles.opacity = 0.1;
+        },
+    });
 
     modal.afterClose((modal) => {
-        let elements = document.getElementById('settings').elements
-        let options = Object.assign({}, opts)
+        let elements = document.getElementById('settings').elements;
+        let options = Object.assign({}, opts);
 
-        let _ = ['theme'].forEach(n => {
-            options[n] = elements[n].value
-        })
+        for (let opt of ['theme']) {
+            options[opt] = elements[opt].value;
+        }
 
-        _ = ['color', 'weight', 'opacity'].forEach(n => {
-            options.lineOptions[n] = elements[n].value
-        })
+        for (let opt of ['color', 'weight', 'opacity']) {
+            options.lineOptions[opt] = elements[opt].value;
+        }
 
-        finishCallback(options)
-        modal.destroy()
+        for (let opt of ['existing']) {
+            options.lineOptions[opt] = elements[opt].checked;
+        }
+        
+        finishCallback(options);
+        modal.destroy();
     })
 
-    return modal
+    return modal;
 }
 
 export function showModal(type) {
     let modal = picoModal({
         content: MODAL_CONTENT[type],
-        overlayStyles: (styles) => { styles.opacity = 0.01 }
+        overlayStyles: (styles) => {
+            styles.opacity = 0.01;
+        },
     })
 
-    modal.show()
+    modal.show();
 
-    return modal
+    return modal;
 }
 
 
 export function initialize(map) {
-    let modal = showModal('help')
+    let modal = showModal('help');
 
-    window.addEventListener('dragover', handleDragOver, false)
+    window.addEventListener('dragover', handleDragOver, false);
 
     window.addEventListener('drop', e => {
         if (!modal.destroyed) {
-            modal.destroy()
-            modal.destroyed = true
+            modal.destroy();
+            modal.destroyed = true;
         }
-        handleFileSelect(map, e)
-    }, false)
+        handleFileSelect(map, e);
+    }, false);
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -139,8 +139,14 @@ function buildUploadModal(numFiles) {
 }
 
 
-export function buildSettingsModal(opts, finishCallback) {
+export function buildSettingsModal(map, opts, finishCallback) {
     let existing = opts.lineOptions.existing ? 'checked' : '';
+    let allSameColor = map.tracks.every(val => (
+        val.options.color === map.tracks[0].options.color));
+    if (map.tracks.length > 0 && !allSameColor) existing = false;
+    else if (map.tracks.length > 0 && allSameColor) {
+        opts.lineOptions.color = map.tracks[0].options.color;
+    }
     let detect = opts.lineOptions.detectColors ? 'checked' : '';
     let themes = AVAILABLE_THEMES.map(t => {
         let selected = t == opts.theme ? 'selected' : '';

--- a/src/ui.js
+++ b/src/ui.js
@@ -186,6 +186,11 @@ export function buildSettingsModal(opts, finishCallback) {
         <input name="weight" type="number" min=1 max=100
             value=${opts.lineOptions.weight}>
     </span>
+
+    <span class="form-row">
+        <label>Apply to existing</label>
+        <input name="existing" type="checkbox" ${checked}>
+    </span>
 </form>
 `;
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,4 +1,4 @@
-import picoModal from 'picoModal'
+import picoModal from 'picomodal'
 import parseGPX from './gpx'
 
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -183,7 +183,7 @@ export function buildSettingsModal(opts, finishCallback) {
 
     <span class="form-row">
         <label>Detect color from Strava bulk export</label>
-        <input name="detect" type="checkbox" ${detect}>
+        <input name="detectColors" type="checkbox" ${detect}>
     </span>
 </form>
 `;
@@ -210,7 +210,7 @@ export function buildSettingsModal(opts, finishCallback) {
             options.lineOptions[opt] = elements[opt].value;
         }
 
-        for (let opt of ['existing', 'detect']) {
+        for (let opt of ['existing', 'detectColors']) {
             options.lineOptions[opt] = elements[opt].checked;
         }
         

--- a/src/ui.js
+++ b/src/ui.js
@@ -144,7 +144,7 @@ export function buildSettingsModal(tracks, opts, finishCallback) {
     let allSameColor = tracks.every(val => {
         return val.options.color === tracks[0].options.color;
     });
-    if (mtracks.length > 0 && !allSameColor) {
+    if (tracks.length > 0 && !allSameColor) {
         overrideExisting = false;
     } else if (tracks.length > 0 && allSameColor) {
         opts.lineOptions.color = tracks[0].options.color;

--- a/src/ui.js
+++ b/src/ui.js
@@ -140,10 +140,10 @@ function buildUploadModal(numFiles) {
 
 
 export function buildSettingsModal(map, opts, finishCallback) {
-    let existing = opts.lineOptions.existing ? 'checked' : '';
+    let overrideExisting = opts.lineOptions.overrideExisting ? 'checked' : '';
     let allSameColor = map.tracks.every(val => (
         val.options.color === map.tracks[0].options.color));
-    if (map.tracks.length > 0 && !allSameColor) existing = false;
+    if (map.tracks.length > 0 && !allSameColor) overrideExisting = false;
     else if (map.tracks.length > 0 && allSameColor) {
         opts.lineOptions.color = map.tracks[0].options.color;
     }
@@ -183,8 +183,8 @@ export function buildSettingsModal(map, opts, finishCallback) {
     </span>
 
     <span class="form-row">
-        <label>Apply to existing</label>
-        <input name="existing" type="checkbox" ${existing}>
+        <label>Override existing tracks</label>
+        <input name="overrideExisting" type="checkbox" ${overrideExisting}>
     </span>
 
     <span class="form-row">
@@ -216,7 +216,7 @@ export function buildSettingsModal(map, opts, finishCallback) {
             options.lineOptions[opt] = elements[opt].value;
         }
 
-        for (let opt of ['existing', 'detectColors']) {
+        for (let opt of ['overrideExisting', 'detectColors']) {
             options.lineOptions[opt] = elements[opt].checked;
         }
         

--- a/src/ui.js
+++ b/src/ui.js
@@ -141,10 +141,12 @@ function buildUploadModal(numFiles) {
 
 export function buildSettingsModal(tracks, opts, finishCallback) {
     let overrideExisting = opts.lineOptions.overrideExisting ? 'checked' : '';
-    let allSameColor = tracks.every(val => (
-        val.options.color === tracks[0].options.color));
-    if (mtracks.length > 0 && !allSameColor) overrideExisting = false;
-    else if (tracks.length > 0 && allSameColor) {
+    let allSameColor = tracks.every(val => {
+        return val.options.color === tracks[0].options.color;
+    });
+    if (mtracks.length > 0 && !allSameColor) {
+        overrideExisting = false;
+    } else if (tracks.length > 0 && allSameColor) {
         opts.lineOptions.color = tracks[0].options.color;
     }
     let detect = opts.lineOptions.detectColors ? 'checked' : '';

--- a/src/ui.js
+++ b/src/ui.js
@@ -10,6 +10,7 @@ const AVAILABLE_THEMES = [
     'Esri.WorldImagery',
     'OpenStreetMap.Mapnik',
     'OpenStreetMap.BlackAndWhite',
+    'Stamen.Terrain',
     'Stamen.TerrainBackground',
     'Stamen.Toner',
     'Stamen.TonerLite',


### PR DESCRIPTION
This lets you change the colour of future track imports without affecting existing tracks, by unchecking the "Apply to existing" setting, as well as automatically choosing colors based on the sport when loading GPX files as bulk-exported from Strava, using the file name.