### PR TITLE
Fix and improve SVG export

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -222,6 +222,16 @@ export default class GpxMap {
 
                 svg.setAttribute('viewBox', `${left} ${top} ${width} ${height}`);
 
+                if (this.options.theme.indexOf('CartoDB.DarkMatter') === 0) {
+                    let background = leaflet.SVG.create('rect');
+                    background.setAttribute('x', left);
+                    background.setAttribute('y', top);
+                    background.setAttribute('width', width);
+                    background.setAttribute('height', height);
+                    background.setAttribute('fill', 'black');
+                    svg.appendChild(background);
+                }
+
                 this.tracks.forEach(track => {
                     // Project each point from LatLng, scale it up, round to
                     // nearest 1/10 (by multiplying by 10, rounding and

--- a/src/map.js
+++ b/src/map.js
@@ -209,11 +209,13 @@ export default class GpxMap {
                 link.innerText = 'Download as SVG';
 
                 const scale = 2;
-                const left = this.map.getPixelOrigin().x * scale;
-                const top = this.map.getPixelOrigin().y * scale;
-                const width = this.map.getSize().x * scale;
-                const height = this.map.getSize().y * scale;
-                const bounds = leaflet.bounds([left, top], [left+width, top+height]);
+                const bounds = this.map.getPixelBounds();
+                bounds.min = bounds.min.multiplyBy(scale);
+                bounds.max = bounds.max.multiplyBy(scale);
+                const left = bounds.min.x;
+                const top = bounds.min.y;
+                const width = bounds.getSize().x;
+                const height = bounds.getSize().y;
 
                 let svg = leaflet.SVG.create('svg');
                 let root = leaflet.SVG.create('g');

--- a/src/map.js
+++ b/src/map.js
@@ -249,7 +249,7 @@ export default class GpxMap {
 
                     el.setAttribute('stroke', track.options.color);
                     el.setAttribute('stroke-opacity', track.options.opacity);
-                    el.setAttribute('stroke-width', track.options.weight);
+                    el.setAttribute('stroke-width', scale * track.options.weight);
                     el.setAttribute('stroke-linecap', 'round');
                     el.setAttribute('stroke-linejoin', 'round');
                     el.setAttribute('fill', 'none');

--- a/src/map.js
+++ b/src/map.js
@@ -222,16 +222,6 @@ export default class GpxMap {
 
                 svg.setAttribute('viewBox', `${left} ${top} ${width} ${height}`);
 
-                if (this.options.theme.indexOf('CartoDB.DarkMatter') === 0) {
-                    let background = leaflet.SVG.create('rect');
-                    background.setAttribute('x', left);
-                    background.setAttribute('y', top);
-                    background.setAttribute('width', width);
-                    background.setAttribute('height', height);
-                    background.setAttribute('fill', 'black');
-                    svg.appendChild(background);
-                }
-
                 this.tracks.forEach(track => {
                     // Project each point from LatLng, scale it up, round to
                     // nearest 1/10 (by multiplying by 10, rounding and


### PR DESCRIPTION
Looks like I didn't test enough: the SVG exports were up to a tile out of place. Should be fixed now. In addition, I've scaled up the lines so they don't decrease in thickness when exported, and added a black background for exports from DarkMatter maps.