### PR TITLE
Fix gzip inflate error handling

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -86,11 +86,15 @@ function extractFITTracks(fit, name) {
 
 
 function readFile(file, encoding, isGzipped) {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
         const reader = new FileReader();
         reader.onload = (e) => {
             const result = e.target.result;
-            resolve(isGzipped ? Pako.inflate(result) : result);
+            try {
+                return resolve(isGzipped ? Pako.inflate(result) : result);
+            } catch (e) {
+                return reject(e);
+            }
         };
 
         if (encoding === 'binary') {


### PR DESCRIPTION
Hey, thanks for this cool project!

This PR makes sure that errors during `Pako.inflate()` are handled correctly and shown in the GUI. Previously, the number of processed activities simply stopped incrementing once an error occurred.