### PR TITLE
Use reduce to remove points with missing coords

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -24,13 +24,18 @@ function extractGPXTracks(gpx) {
         let name = trk.name && trk.name.length > 0 ? trk.name[0] : 'untitled';
 
         trk.trkseg.forEach(trkseg => {
-            let points = trkseg.trkpt.map(trkpt => ({
-                lat: parseFloat(trkpt.$.lat),
-                lng: parseFloat(trkpt.$.lon),
-                // These are available to us, but are currently unused
-                // elev: parseFloat(trkpt.ele) || 0,
-                // time: new Date(trkpt.time || '0')
-            }));
+            let points = trkseg.trkpt.reduce(function(result, trkpt) {
+                if (typeof trkpt.$ !== 'undefined') {
+                    result.push({
+                        lat: parseFloat(trkpt.$.lat),
+                        lng: parseFloat(trkpt.$.lon),
+                        // These are available to us, but are currently unused
+                        // elev: parseFloat(trkpt.ele) || 0,
+                        // time: new Date(trkpt.time || '0')
+                    });
+                }
+                return result;
+            }, []);
 
             parsedTracks.push({points, name});
         });

--- a/src/track.js
+++ b/src/track.js
@@ -25,7 +25,10 @@ function extractGPXTracks(gpx) {
 
         trk.trkseg.forEach(trkseg => {
             let points = trkseg.trkpt.reduce(function(result, trkpt) {
-                if (typeof trkpt.$ !== 'undefined') {
+                if (typeof trkpt.$ !== 'undefined'
+                  && typeof trkpt.$.lat !== 'undefined'
+                  && typeof trkpt.$.lon !== 'undefined'
+                ) {
                     result.push({
                         lat: parseFloat(trkpt.$.lat),
                         lng: parseFloat(trkpt.$.lon),


### PR DESCRIPTION
Thanks for this great site!

I have a GPX from my Strava ZIP that looks like this (I've snipped away most of the track points), where the first `<trkpt>` has no `lon` or `lat` attributes:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" creator="Wahoo ELEMNT BOLT" version="5.8">
  <metadata>
    <link href="https://gotoes.org/strava/Combine_GPX_TCX_FIT_Files.php">
      <text>GOTOES STRAVA TOOLS</text>
    </link>
    <time>2019-08-31T09:02:36Z</time>
  </metadata>
  <trk>
    <type>Other</type>
    <trkseg>
      <trkpt>
        <ele>31.2</ele>
        <time>2019-08-31T09:02:36Z</time>
        <extensions>
          <gpxdata:temp>0</gpxdata:temp>
        </extensions>
      </trkpt>
      <trkpt lon="24.93841" lat="60.16992">
        <ele>31.2</ele>
        <time>2019-08-31T09:02:37Z</time>
        <extensions>
          <gpxdata:temp>29</gpxdata:temp>
        </extensions>
      </trkpt>
      <trkpt lon="24.93841" lat="60.16992">
        <ele>31.2</ele>
        <time>2019-08-31T09:02:38Z</time>
        <extensions>
          <gpxdata:temp>29</gpxdata:temp>
        </extensions>
      </trkpt>
    </trkseg>
  </trk>
</gpx>
```

It fails to load at https://erik.github.io/derive/ and logs this in the console:

```
ui.js:105 TypeError: Cannot read property 'lat' of undefined
    at track.js:28
    at Array.map (<anonymous>)
    at track.js:27
    at Array.forEach (<anonymous>)
    at track.js:26
    at Array.forEach (<anonymous>)
    at track.js:23
    at track.js:137
    at f.<anonymous> (parser.js:303)
    at f.a.emit (events.js:146)
    at o.onclosetag (parser.js:261)
    at P (sax.js:624)
    at L (sax.js:629)
    at B (sax.js:889)
    at o.write (sax.js:1436)
    at f.parseString (parser.js:322)
    at f.parseString (parser.js:5)
    at track.js:133
    at new Promise (<anonymous>)
    at track.js:132
(anonymous) @ ui.js:105
w @ runtime.js:65
(anonymous) @ runtime.js:303
t.<computed> @ runtime.js:117
S @ image.js:62
a @ image.js:62
Promise.then (async)
S @ image.js:62
s @ image.js:62
(anonymous) @ image.js:62
(anonymous) @ image.js:62
(anonymous) @ ui.js:97
C @ ui.js:110
(anonymous) @ ui.js:356
```

The error is here:
 https://github.com/erik/derive/blob/88b9255c795cb7802969e35a1c96aa717d02afcf/src/track.js#L26-L33

It happens because the first track point doesn't have latitude or longitude attributes (see GPX above).

This fix is use `reduce` instead of `map`, and discard track points unless they have attributes. (A chained `filter` and `map` could be used, but this should have better performance for thousands of points.)

About the data: the problematic file was generated by combining two files using [this tool](https://gotoes.org/strava/Combine_GPX_TCX_FIT_Files.php), which is [recommended by Strava](https://support.strava.com/hc/en-us/articles/221258108-Merge-or-combine-activities) so will be quite widely used. I don't have the original pre-merge files handy to check if the same issue occurs there or if it was introduced by the merge tool.

I've tested the fix locally with my full Strava archive (1,330 files) and they all load.
