### PR TITLE
Add rudimentary filter support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ http://library.nothingness.org/articles/SI/en/display/314
 If you use Strava, go to your
 [account download page](https://www.strava.com/athlete/delete_your_account)
 and click "Request your archive". You'll get an email containing a ZIP
-file of all the GPS tracks you've logged so far: this can take several hours.
+file of all the GPS tracks you've logged so far. This can take several hours.
 
 ## Developing
 

--- a/src/map.js
+++ b/src/map.js
@@ -3,7 +3,7 @@ import leafletImage from 'leaflet-image';
 import 'leaflet-providers';
 import 'leaflet-easybutton';
 
-import {buildSettingsModal, showModal} from  './ui';
+import * as ui from './ui';
 
 
 // Los Angeles is the center of the universe
@@ -33,6 +33,10 @@ export default class GpxMap {
     constructor(options) {
         this.options = options || DEFAULT_OPTIONS;
         this.tracks = [];
+        this.filters = {
+            minDate: null,
+            maxDate: null,
+        };
         this.imageMarkers = [];
 
         this.map = leaflet.map('background-map', {
@@ -48,7 +52,7 @@ export default class GpxMap {
                 stateName: 'default',
                 title: 'Export as png',
                 onClick: () => {
-                    let modal = showModal('exportImage')
+                    let modal = ui.showModal('exportImage')
                         .afterClose(() => modal.destroy());
 
                     document.getElementById('render-export').onclick = (e) => {
@@ -71,11 +75,26 @@ export default class GpxMap {
                 stateName: 'default',
                 title: 'Open settings dialog',
                 onClick: () => {
-                    buildSettingsModal(this.tracks, this.options, (opts) => {
+                    ui.buildSettingsModal(this.tracks, this.options, (opts) => {
                         this.updateOptions(opts);
                     }).show();
                 },
             }],
+        }).addTo(this.map);
+
+        leaflet.easyButton({
+            type: 'animate',
+            states: [{
+                icon: 'fa-filter fa-lg',
+                stateName: 'default',
+                title: 'Filter displayed tracks',
+                onClick: () => {
+                    ui.buildFilterModal(this.tracks, this.filters, (f) => {
+                        this.filters = f;
+                        this.applyFilters();
+                    }).show();
+                }
+            }]
         }).addTo(this.map);
 
         this.viewAll = leaflet.easyButton({
@@ -121,14 +140,14 @@ export default class GpxMap {
         }
 
         if (opts.lineOptions.overrideExisting) {
-            this.tracks.forEach(t => {
-                t.setStyle({
+            this.tracks.forEach(({line}) => {
+                line.setStyle({
                     color: opts.lineOptions.color,
                     weight: opts.lineOptions.weight,
                     opacity: opts.lineOptions.opacity,
                 });
 
-                t.redraw();
+                line.redraw();
             });
 
             let markerOptions = opts.markerOptions;
@@ -146,6 +165,29 @@ export default class GpxMap {
         }
 
         this.options = opts;
+    }
+
+    applyFilters () {
+        for (let track of this.tracks) {
+            let show = true;
+
+            // Timestamp based filtering
+            if (track.time) {
+                const {minDate, maxDate} = this.filters;
+                if (minDate && new Date(minDate) > track.time ||
+                    maxDate && new Date(maxDate) < track.time) {
+                    show = false;
+                }
+            }
+
+            if (!show && track.visible) {
+                track.visible = false;
+                track.line.remove();
+            } else if (show && !track.visible){
+                track.line.addTo(this.map);
+                track.visible = true;
+            }
+        }
     }
 
     // Try to pull geo location from browser and center the map
@@ -180,7 +222,7 @@ export default class GpxMap {
         let line = leaflet.polyline(track.points, lineOptions);
         line.addTo(this.map);
 
-        this.tracks.push(line);
+        this.tracks.push(Object.assign({line, visible: true}, track));
     }
 
     async markerClick(image) {
@@ -226,7 +268,8 @@ export default class GpxMap {
             return;
         }
 
-        let tracksAndImages = this.tracks.concat(this.imageMarkers);
+        let tracksAndImages = this.tracks.map(t => t.line)
+            .concat(this.imageMarkers);
 
         this.map.fitBounds((new leaflet.featureGroup(tracksAndImages)).getBounds(), {
             noMoveStart: true,

--- a/src/track.js
+++ b/src/track.js
@@ -22,13 +22,13 @@ function extractGPXTracks(gpx) {
 
     gpx.trk && gpx.trk.forEach(trk => {
         let name = trk.name && trk.name.length > 0 ? trk.name[0] : 'untitled';
-        let time;
+        let timestamp;
 
         trk.trkseg.forEach(trkseg => {
             let points = [];
             for (let trkpt of trkseg.trkpt) {
                 if (trkpt.time && typeof trkpt.time[0] === 'string') {
-                    time = new Date(trkpt.time[0]);
+                    timestamp = new Date(trkpt.time[0]);
                 }
                 if (typeof trkpt.$ !== 'undefined' &&
                     typeof trkpt.$.lat !== 'undefined' &&
@@ -42,17 +42,17 @@ function extractGPXTracks(gpx) {
                 }
             }
 
-            parsedTracks.push({time, points, name});
+            parsedTracks.push({timestamp, points, name});
         });
     });
 
     gpx.rte && gpx.rte.forEach(rte => {
         let name = rte.name && rte.name.length > 0 ? rte.name[0] : 'untitled';
-        let time;
+        let timestamp;
         let points = [];
         for (let pt of rte.rtept) {
             if (pt.time && typeof pt.time[0] === 'string') {
-                time = new Date(pt.time[0]);
+                timestamp = new Date(pt.time[0]);
             }
             points.push({
                 lat: parseFloat(pt.$.lat),
@@ -60,7 +60,7 @@ function extractGPXTracks(gpx) {
             });
         }
 
-        parsedTracks.push({time, points, name});
+        parsedTracks.push({timestamp, points, name});
     });
 
     return parsedTracks;
@@ -76,12 +76,12 @@ function extractTCXTracks(tcx, name) {
     for (const act of tcx.Activities[0].Activity) {
         for (const lap of act.Lap) {
             let trackPoints = lap.Track[0].Trackpoint.filter(it => it.Position);
-            let time;
+            let timestamp;
             let points = []
 
             for (let trkpt of trackPoints) {
                 if (trkpt.Time && typeof trkpt.Time[0] === 'string') {
-                    time = new Date(trkpt.Time[0]);
+                    timestamp = new Date(trkpt.Time[0]);
                 }
                 points.push({
                     lat: parseFloat(trkpt.Position[0].LatitudeDegrees[0]),
@@ -91,7 +91,7 @@ function extractTCXTracks(tcx, name) {
                 });
             }
 
-            parsedTracks.push({time, points, name});
+            parsedTracks.push({timestamp, points, name});
         }
     }
 
@@ -104,7 +104,7 @@ function extractFITTracks(fit, name) {
         throw new Error('Unexpected FIT file format.');
     }
 
-    let time;
+    let timestamp;
     const points = [];
     for (const record of fit.records) {
         if (record.position_lat && record.position_long) {
@@ -114,10 +114,10 @@ function extractFITTracks(fit, name) {
                 // Other available fields: timestamp, distance, altitude, speed, heart_rate
             });
         }
-        record.timestamp && (time = record.timestamp);
+        record.timestamp && (timestamp = record.timestamp);
     }
 
-    return [{time, points, name}];
+    return [{timestamp, points, name}];
 }
 
 

--- a/src/track.js
+++ b/src/track.js
@@ -22,37 +22,45 @@ function extractGPXTracks(gpx) {
 
     gpx.trk && gpx.trk.forEach(trk => {
         let name = trk.name && trk.name.length > 0 ? trk.name[0] : 'untitled';
+        let time;
 
         trk.trkseg.forEach(trkseg => {
-            let points = trkseg.trkpt.reduce(function(result, trkpt) {
-                if (typeof trkpt.$ !== 'undefined'
-                  && typeof trkpt.$.lat !== 'undefined'
-                  && typeof trkpt.$.lon !== 'undefined'
-                ) {
-                    result.push({
+            let points = [];
+            for (let trkpt of trkseg.trkpt) {
+                if (trkpt.time && typeof trkpt.time[0] === 'string') {
+                    time = new Date(trkpt.time[0]);
+                }
+                if (typeof trkpt.$ !== 'undefined' &&
+                    typeof trkpt.$.lat !== 'undefined' &&
+                    typeof trkpt.$.lon !== 'undefined') {
+                    points.push({
                         lat: parseFloat(trkpt.$.lat),
                         lng: parseFloat(trkpt.$.lon),
                         // These are available to us, but are currently unused
                         // elev: parseFloat(trkpt.ele) || 0,
-                        // time: new Date(trkpt.time || '0')
                     });
                 }
-                return result;
-            }, []);
+            }
 
-            parsedTracks.push({points, name});
+            parsedTracks.push({time, points, name});
         });
     });
 
     gpx.rte && gpx.rte.forEach(rte => {
         let name = rte.name && rte.name.length > 0 ? rte.name[0] : 'untitled';
+        let time;
+        let points = [];
+        for (let pt of rte.rtept) {
+            if (pt.time && typeof pt.time[0] === 'string') {
+                time = new Date(pt.time[0]);
+            }
+            points.push({
+                lat: parseFloat(pt.$.lat),
+                lng: parseFloat(pt.$.lon),
+            });
+        }
 
-        let points = rte.rtept.map(pt => ({
-            lat: parseFloat(pt.$.lat),
-            lng: parseFloat(pt.$.lon),
-        }));
-
-        parsedTracks.push({points, name});
+        parsedTracks.push({time, points, name});
     });
 
     return parsedTracks;
@@ -65,20 +73,25 @@ function extractTCXTracks(tcx, name) {
     }
 
     const parsedTracks = [];
-
     for (const act of tcx.Activities[0].Activity) {
         for (const lap of act.Lap) {
-            let points = lap.Track[0].Trackpoint
-                .filter(trkpt => trkpt.Position)
-                .map(trkpt => ({
+            let trackPoints = lap.Track[0].Trackpoint.filter(it => it.Position);
+            let time;
+            let points = []
+
+            for (let trkpt of trackPoints) {
+                if (trkpt.Time && typeof trkpt.Time[0] === 'string') {
+                    time = new Date(trkpt.Time[0]);
+                }
+                points.push({
                     lat: parseFloat(trkpt.Position[0].LatitudeDegrees[0]),
                     lng: parseFloat(trkpt.Position[0].LongitudeDegrees[0]),
                     // These are available to us, but are currently unused
                     // elev: parseFloat(trkpt.ElevationMeters[0]) || 0,
-                    // time: new Date(trkpt.Time[0] || '0')
-                }));
+                });
+            }
 
-            parsedTracks.push({points, name});
+            parsedTracks.push({time, points, name});
         }
     }
 
@@ -91,6 +104,7 @@ function extractFITTracks(fit, name) {
         throw new Error('Unexpected FIT file format.');
     }
 
+    let time;
     const points = [];
     for (const record of fit.records) {
         if (record.position_lat && record.position_long) {
@@ -100,10 +114,10 @@ function extractFITTracks(fit, name) {
                 // Other available fields: timestamp, distance, altitude, speed, heart_rate
             });
         }
+        record.timestamp && (time = record.timestamp);
     }
 
-
-    return [{points, name}];
+    return [{time, points, name}];
 }
 
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -27,7 +27,7 @@ const MODAL_CONTENT = {
 <p>If you use Strava, go to your
 <a href="https://www.strava.com/athlete/delete_your_account">account download
 page</a> and click "Request your archive". You'll get an email containing a ZIP
-file of all the GPS tracks you've logged so far: this can take several hours.
+file of all the GPS tracks you've logged so far. This can take several hours.
 </p>
 
 <p>All processing happens in your browser. Your files will not be uploaded or
@@ -99,7 +99,6 @@ function handleFileSelect(map, evt) {
             if (/\.jpe?g$/i.test(file.name)) {
                 return await handleImage(file);
             }
-
             return await handleTrackFile(file);
         } catch (err) {
             console.error(err);
@@ -109,7 +108,6 @@ function handleFileSelect(map, evt) {
 
     Promise.all(files.map(handleFile)).then(() => {
         map.center();
-
         modal.finished();
     });
 }
@@ -201,21 +199,20 @@ export function buildSettingsModal(tracks, opts, finishCallback) {
     let overrideExisting = opts.lineOptions.overrideExisting ? 'checked' : '';
 
     if (tracks.length > 0) {
-        let allSameColor = tracks.every(trk => {
-            return trk.options.color === tracks[0].options.color;
+        let allSameColor = tracks.every(({line}) => {
+            return line.options.color === tracks[0].line.options.color;
         });
 
         if (!allSameColor) {
             overrideExisting = false;
         } else {
-            opts.lineOptions.color = tracks[0].options.color;
+            opts.lineOptions.color = tracks[0].line.options.color;
         }
     }
 
     let detect = opts.lineOptions.detectColors ? 'checked' : '';
     let themes = AVAILABLE_THEMES.map(t => {
         let selected = (t === opts.theme) ? 'selected' : '';
-
         return `<option ${selected} value="${t}">${t}</option>`;
     });
 
@@ -329,6 +326,61 @@ export function buildSettingsModal(tracks, opts, finishCallback) {
     return modal;
 }
 
+export function buildFilterModal(tracks, filters, finishCallback) {
+    let dateBounds = tracks
+        .map(it => it.time || new Date(0))
+        .reduce(({min, max}, date) => {
+            if (!min || date < min) { min = date };
+            if (!max || date > max) { max = date };
+            return {min, max};
+        }, {min: '', max: ''});
+
+    let modalContent = `
+<h3>Filter Displayed Tracks</h3>
+
+<form id="settings">
+    <span class="form-row">
+        <label for="minDate">Start date:</label>
+        <input type="date" id="minDate" name="minDate"
+            value="${filters.minDate || ''}"
+            min="${dateBounds.min}"
+            max="${dateBounds.max}">
+    </span>
+
+    <span class="form-row">
+        <label for="maxDate">End date:</label>
+        <input type="date" id="maxDate" name="maxDate"
+            value="${filters.maxDate || ''}"
+            min="${dateBounds.min}"
+            max="${dateBounds.max}">
+    </span>
+</form>`;
+
+    let modal = picoModal({
+        content: modalContent,
+        closeButton: true,
+        escCloses: true,
+        overlayClose: true,
+        overlayStyles: (styles) => {
+            styles.opacity = 0.1;
+        },
+    });
+
+    modal.afterClose((modal) => {
+        let elements = document.getElementById('settings').elements;
+        let filters = Object.assign({}, filters);
+
+        for (let key of ['minDate', 'maxDate']) {
+            filters[key] = elements[key].value;
+        }
+
+        finishCallback(filters);
+        modal.destroy();
+    });
+
+    return modal;
+}
+
 export function showModal(type) {
     let modal = picoModal({
         content: MODAL_CONTENT[type],
@@ -338,7 +390,6 @@ export function showModal(type) {
     });
 
     modal.show();
-
     return modal;
 }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -327,14 +327,7 @@ export function buildSettingsModal(tracks, opts, finishCallback) {
 }
 
 export function buildFilterModal(tracks, filters, finishCallback) {
-    let dateBounds = tracks
-        .map(it => it.time || new Date(0))
-        .reduce(({min, max}, date) => {
-            if (!min || date < min) { min = date };
-            if (!max || date > max) { max = date };
-            return {min, max};
-        }, {min: '', max: ''});
-
+    let maxDate = new Date().toISOString().split('T')[0];
     let modalContent = `
 <h3>Filter Displayed Tracks</h3>
 
@@ -343,16 +336,16 @@ export function buildFilterModal(tracks, filters, finishCallback) {
         <label for="minDate">Start date:</label>
         <input type="date" id="minDate" name="minDate"
             value="${filters.minDate || ''}"
-            min="${dateBounds.min}"
-            max="${dateBounds.max}">
+            min="1990-01-01"
+            max="${maxDate}">
     </span>
 
     <span class="form-row">
         <label for="maxDate">End date:</label>
         <input type="date" id="maxDate" name="maxDate"
             value="${filters.maxDate || ''}"
-            min="${dateBounds.min}"
-            max="${dateBounds.max}">
+            min="1990-01-01"
+            max="${maxDate}">
     </span>
 </form>`;
 


### PR DESCRIPTION
This adds some basic filters for start and end dates, which can be
applied and modified after the tracks have been loaded, to show e.g. all
activities in a 1 year period.

Adds more debt to the pile for this horrible hacky UI wiring. Blah.

![image](https://user-images.githubusercontent.com/188935/69758529-9bda1400-1114-11ea-96dc-ef50544b1f67.png)
