### PR TITLE
Add 'No map' option to show white background

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -130,8 +130,10 @@ export default class GpxMap {
             this.mapTiles.removeFrom(this.map);
         }
 
-        this.mapTiles = leaflet.tileLayer.provider(themeName);
-        this.mapTiles.addTo(this.map, {detectRetina: true});
+        if (themeName !== 'No map') {
+            this.mapTiles = leaflet.tileLayer.provider(themeName);
+            this.mapTiles.addTo(this.map, {detectRetina: true});
+        }
     }
 
     updateOptions(opts) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -18,6 +18,7 @@ const AVAILABLE_THEMES = [
     'Stamen.TonerLite',
     'Stamen.TonerBackground',
     'Stamen.Watercolor',
+    'No map',
 ];
 
 const MODAL_CONTENT = {

--- a/style.css
+++ b/style.css
@@ -11,6 +11,7 @@ a {
 }
 
 #background-map {
+    background-color: white;
     position: absolute;
     top: 0;
     right: 0;


### PR DESCRIPTION
Here's a quick go to fix #34.

Screenshot:

![image](https://user-images.githubusercontent.com/1324225/71583335-abcf8400-2b16-11ea-880f-db23b144c064.png)

Exported PNG has a transparent background:

![derive-export](https://user-images.githubusercontent.com/1324225/71583361-c3a70800-2b16-11ea-8b25-aae9a4045a2f.png)
