### PR TITLE
Persist configuration options to localStorage.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,8 @@ import {initialize} from './ui';
 
 function app() {
     let map = new GpxMap();
+    map.restoreSavedOptions();
+
     initialize(map);
 }
 

--- a/src/map.js
+++ b/src/map.js
@@ -77,6 +77,7 @@ export default class GpxMap {
                 onClick: () => {
                     ui.buildSettingsModal(this.tracks, this.options, (opts) => {
                         this.updateOptions(opts);
+                        this.saveOptions(opts);
                     }).show();
                 },
             }],
@@ -133,6 +134,23 @@ export default class GpxMap {
         if (themeName !== 'No map') {
             this.mapTiles = leaflet.tileLayer.provider(themeName);
             this.mapTiles.addTo(this.map, {detectRetina: true});
+        }
+    }
+
+    saveOptions(opts) {
+        window.localStorage.setItem('options', JSON.stringify(opts));
+    }
+
+    restoreSavedOptions() {
+        if (window.localStorage.getItem('options') === null) {
+            return;
+        }
+
+        let opts = window.localStorage.getItem('options');
+        opts = JSON.parse(opts);
+
+        if (typeof opts === 'object') {
+            this.updateOptions(opts);
         }
     }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -388,13 +388,25 @@ export function showModal(type) {
 }
 
 
+const INTRO_MODAL_SEEN_KEY = 'intro-modal-seen';
+
 export function initialize(map) {
-    let modal = showModal('help');
+    // We don't need to show the help modal every time, only the first
+    // time the user sees the page.
+    let displayIntroModal = true;
+
+    if (window.sessionStorage.getItem(INTRO_MODAL_SEEN_KEY) !== null) {
+        displayIntroModal = false;
+    } else {
+        window.sessionStorage.setItem(INTRO_MODAL_SEEN_KEY, 'true');
+    }
+
+
+    let modal = displayIntroModal ? showModal('help') : null;
 
     window.addEventListener('dragover', handleDragOver, false);
-
     window.addEventListener('drop', e => {
-        if (!modal.destroyed) {
+        if (displayIntroModal && !modal.destroyed) {
             modal.destroy();
             modal.destroyed = true;
         }


### PR DESCRIPTION
Allows any configuration changes (color, basemap, etc.) to survive page
reloads.

Also - show the intro help modal only once per session.

Fixes #44.