### PR TITLE
IGC format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Generate a heatmap from GPS tracks.
 
-Drag and drop one or more GPX/TCX/FIT files or JPEG images into the browser
+Drag and drop one or more GPX/TCX/FIT/IGC files or JPEG images into the browser
 window. No data is ever uploaded, everything is done client side.
 
 Loosely inspired by [The Passage Ride](http://thepassageride.com), which you

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "exif-js": "^2.3.0",
     "fit-file-parser": "^1.6.18",
+    "igc-parser": "^0.5.0",
     "leaflet": "^1.3.3",
     "leaflet-easybutton": "^2.3.0",
     "leaflet-image": "^0.4.0",

--- a/src/track.js
+++ b/src/track.js
@@ -130,7 +130,6 @@ function extractFITTracks(fit, name) {
 }
 
 function extractIGCTracks(igc) {
-  debugger;
   const points = [];
   let timestamp = null;
   for (const fix of igc.fixes) {

--- a/src/track.js
+++ b/src/track.js
@@ -209,7 +209,7 @@ export default function extractTracks(file) {
     case 'igc':
         return readFile(file, 'text', isGzipped)
             .then(textContents => new Promise((resolve, reject) => {
-                resolve(extractIGCTracks(IGCParser.parse(textContents)));
+                resolve(extractIGCTracks(IGCParser.parse(textContents, {lenient: true})));
             }));
 
     default:

--- a/src/track.js
+++ b/src/track.js
@@ -141,7 +141,7 @@ function extractIGCTracks(igc) {
     });
     timestamp = timestamp || new Date(fix.timestamp);
   }
-  const name = "igc";
+  const name = 'igc';
   return points.length > 0 ? [{timestamp, points, name}] : [];
 }
 
@@ -208,7 +208,7 @@ export default function extractTracks(file) {
 
     case 'igc':
         return readFile(file, 'text', isGzipped)
-            .then(textContents => new Promise((resolve, reject) => {
+            .then(textContents => new Promise((resolve) => {
                 resolve(extractIGCTracks(IGCParser.parse(textContents, {lenient: true})));
             }));
 

--- a/src/track.js
+++ b/src/track.js
@@ -207,8 +207,12 @@ export default function extractTracks(file) {
 
     case 'igc':
         return readFile(file, 'text', isGzipped)
-            .then(textContents => new Promise((resolve) => {
-                resolve(extractIGCTracks(IGCParser.parse(textContents, {lenient: true})));
+            .then(textContents => new Promise((resolve, reject) => {
+                try {
+                    resolve(extractIGCTracks(IGCParser.parse(textContents, {lenient: true})));
+                } catch(err) {
+                    reject(err);
+                }
             }));
 
     default:

--- a/src/ui.js
+++ b/src/ui.js
@@ -24,7 +24,7 @@ const AVAILABLE_THEMES = [
 const MODAL_CONTENT = {
     help: `
 <h1>dérive</h1>
-<h4>Drag and drop one or more GPX/TCX/FIT files or JPEG images here.</h4>
+<h4>Drag and drop one or more GPX/TCX/FIT/IGC files or JPEG images here.</h4>
 <p>If you use Strava, go to your
 <a href="https://www.strava.com/athlete/delete_your_account">account download
 page</a> and click "Request your archive". You'll get an email containing a ZIP


### PR DESCRIPTION
Add support for the IGC format.

This format is used to record various gliding tracks (sailplanes, hang gliders, paragliders).

Random public example: https://www.xcontest.org/world/en/flights/detail:Enio/2.01.2021/15:56 (click on "IGC file" to download)