### PR TITLE
Apply changes to the options on the fly

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -196,7 +196,7 @@ function buildUploadModal(numFiles) {
 }
 
 
-export function buildSettingsModal(tracks, opts, finishCallback) {
+export function buildSettingsModal(tracks, opts, updateCallback) {
     let overrideExisting = opts.lineOptions.overrideExisting ? 'checked' : '';
 
     if (tracks.length > 0) {
@@ -299,7 +299,7 @@ export function buildSettingsModal(tracks, opts, finishCallback) {
         },
     });
 
-    modal.afterClose((modal) => {
+    let applyOptions = () => {
         let elements = document.getElementById('settings').elements;
         let options = Object.assign({}, opts);
 
@@ -320,9 +320,22 @@ export function buildSettingsModal(tracks, opts, finishCallback) {
             options.lineOptions[opt] = elements[opt].checked;
         }
 
-        finishCallback(options);
-        modal.destroy();
+        updateCallback(options);
+    };
+
+    modal.afterClose((modal) => {
+      applyOptions();
+      modal.destroy();
     });
+
+    modal.afterCreate(() => {
+      let elements = document.getElementById('settings').elements;
+      for (let opt of ['theme', 'color', 'weight', 'opacity', 'markerColor',
+                       'markerWeight', 'markerOpacity', 'markerRadius']) {
+        elements[opt].addEventListener('change', applyOptions);
+      }
+    });
+
 
     return modal;
 }


### PR DESCRIPTION
Apply options changes on the fly instead of only after options window is closed.

Makes it much easier to find a suitable combination.