### PR TITLE
Add support for SKIZ format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Generate a heatmap from GPS tracks.
 
-Drag and drop one or more GPX/TCX/FIT/IGC files or JPEG images into the browser
+Drag and drop one or more GPX/TCX/FIT/IGC/SKIZ files or JPEG images into the browser
 window. No data is ever uploaded, everything is done client side.
 
 Loosely inspired by [The Passage Ride](http://thepassageride.com), which you

--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,6 +2063,11 @@
         "isarray": "^1.0.0"
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2813,6 +2818,14 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
+    },
+    "csv-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.0.0.tgz",
+      "integrity": "sha512-s6OYSXAK3IdKqYO33y09jhypG/bSDHPuyCme/IdEHfWpLf/jKcpitVFyOC6UemgGk8v7Q5u2XE0vvwmanxhGlQ==",
+      "requires": {
+        "minimist": "^1.2.0"
+      }
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -3579,11 +3592,24 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+    },
     "fastparse": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
       "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
       "dev": true
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -5070,8 +5096,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -5692,6 +5717,11 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -6497,6 +6527,16 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "skiz-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/skiz-parser/-/skiz-parser-1.4.0.tgz",
+      "integrity": "sha512-1imVXEfpClP0/XvUJvq2VCF2jI/2A4WX8KoVaHrYYZoCLNUFFj/cCtVoJc57LT5hOH3rGt1iLh+8dmWDMWy8gg==",
+      "requires": {
+        "csv-parser": "^3.0.0",
+        "fast-xml-parser": "^3.19.0",
+        "yauzl": "^2.10.0"
+      }
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -8261,6 +8301,15 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "ylru": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "leaflet-providers": "^1.3.1",
     "pako": "^1.0.6",
     "picomodal": "^3.0.0",
+    "skiz-parser": "^1.4.0",
     "xml2js": "^0.4.19"
   },
   "devDependencies": {

--- a/src/ui.js
+++ b/src/ui.js
@@ -24,7 +24,7 @@ const AVAILABLE_THEMES = [
 const MODAL_CONTENT = {
     help: `
 <h1>dérive</h1>
-<h4>Drag and drop one or more GPX/TCX/FIT/IGC files or JPEG images here.</h4>
+<h4>Drag and drop one or more GPX/TCX/FIT/IGC/SKIZ files or JPEG images here.</h4>
 <p>If you use Strava, go to your
 <a href="https://www.strava.com/athlete/delete_your_account">account download
 page</a> and click "Request your archive". You'll get an email containing a ZIP

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
                 }
             }
         ]
+    },
+    node: {
+        fs: 'empty'
     }
 };


### PR DESCRIPTION
Add support for the SKIZ format which is the format is used by the [Ski Tracks](https://www.skitracks.com/) mobile app.

Sample file can be downloaded here: https://github.com/kirkeaton/skiz-parser/raw/main/test/example.skiz

