### PR TITLE
Fix .gpx.gz decompression

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -168,13 +168,24 @@ function readFile(file, encoding, isGzipped) {
         reader.onload = (e) => {
             const result = e.target.result;
             try {
-                return resolve(isGzipped ? Pako.inflate(result) : result);
+                if (isGzipped) {
+                    const inflated = Pako.inflate(result);
+                    // For text files, convert the Uint8Array back to string
+                    if (encoding === 'text') {
+                        const decoder = new TextDecoder('utf-8');
+                        return resolve(decoder.decode(inflated));
+                    } else {
+                        return resolve(inflated);
+                    }
+                } else {
+                    return resolve(result);
+                }
             } catch (e) {
                 return reject(e);
             }
         };
 
-        if (encoding === 'binary') {
+        if (encoding === 'binary' || isGzipped) {
             reader.readAsArrayBuffer(file);
         } else {
             reader.readAsText(file);


### PR DESCRIPTION
Hi, I found a problem when importing my Strava activities.

<img width="269" height="513" alt="image" src="https://github.com/user-attachments/assets/3cb58330-24a2-4dd8-b446-0637ab5fabf7" />

Around 20 `.gpx.gz` files failed to import. They were just compressed versions of GPX files. When I tried to inflate them they worked just fine. After inspecting the code I found a solution. The inflated text files need to be properly decoded to string, otherwise they fail to read.

Now all of my activities render properly on map without errors.