### PR TITLE
Parse activity type and use for automatic coloring

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -28,6 +28,15 @@ const DEFAULT_OPTIONS = {
     }
 };
 
+// Color mapping for different activity types
+const ACTIVITY_COLORS = {
+    'walking': '#ffc0cb',
+    'hiking': '#ffc0cb',
+    'running': '#ff0000',
+    'cycling': '#00ff00',
+    'swimming': '#0000ff',
+};
+
 
 export default class GpxMap {
     constructor(options) {
@@ -233,12 +242,23 @@ export default class GpxMap {
         let lineOptions = Object.assign({}, this.options.lineOptions);
 
         if (lineOptions.detectColors) {
+            // set line option color depending on activity type:
+            if (track.activityType) {
+                const color = ACTIVITY_COLORS[track.activityType.toLowerCase()];
+                if (color) {
+                    lineOptions.color = color;
+                }
+            }
+
+            // Legacy support for file-ending colors:
             if (/-(Hike|Walk)\.gpx/.test(track.filename)) {
-                lineOptions.color = '#ffc0cb';
+                lineOptions.color = ACTIVITY_COLORS["hiking"];
             } else if (/-Run\.gpx/.test(track.filename)) {
-                lineOptions.color = '#ff0000';
+                lineOptions.color = ACTIVITY_COLORS["running"];
             } else if (/-Ride\.gpx/.test(track.filename)) {
-                lineOptions.color = '#00ffff';
+                lineOptions.color = ACTIVITY_COLORS["cycling"];
+            } else if (/-Swim\.gpx/.test(track.filename)) {
+                lineOptions.color = ACTIVITY_COLORS["swimming"];
             }
         }
 

--- a/src/track.js
+++ b/src/track.js
@@ -43,6 +43,7 @@ function extractGPXTracks(gpx) {
 
     for (const trk of tracks) {
         const name = getTextContent(trk, 'name') || 'untitled';
+        const activityType = getTextContent(trk, 'type') || null;
         let timestamp;
 
         for (const trkseg of queryElements(trk, 'trkseg')) {
@@ -68,7 +69,7 @@ function extractGPXTracks(gpx) {
             }
 
             if (points.length > 0) {
-                parsedTracks.push({ timestamp, points, name });
+                parsedTracks.push({ timestamp, points, name, activityType });
             }
         }
     }
@@ -112,6 +113,7 @@ function extractTCXTracks(tcx, name) {
     }
 
     const parsedTracks = [];
+    const activityType = activities[0].getAttribute('Sport') || null;
 
     for (const activity of activities) {
         const laps = queryElements(activity, 'Lap');
@@ -153,7 +155,7 @@ function extractTCXTracks(tcx, name) {
                 }
 
                 if (points.length > 0) {
-                    parsedTracks.push({ timestamp, points, name });
+                    parsedTracks.push({ timestamp, points, name, activityType });
                 }
             }
         }
@@ -170,6 +172,7 @@ function extractFITTracks(fit, name) {
 
     let timestamp;
     const points = [];
+    const activityType = fit.sport ? fit.sport.sport.toLowerCase() : null;
     for (const record of fit.records) {
         if (record.position_lat && record.position_long) {
             points.push({
@@ -181,7 +184,7 @@ function extractFITTracks(fit, name) {
         record.timestamp && (timestamp = record.timestamp);
     }
 
-    return points.length > 0 ? [{ timestamp, points, name }] : [];
+    return points.length > 0 ? [{ timestamp, points, name, activityType }] : [];
 }
 
 function extractIGCTracks(igc) {


### PR DESCRIPTION
This change adds activity type parsing functionality for the strava-supported file formats, i.e. GPX/TCX/FIT
(https://developers.strava.com/docs/uploads/).

Supported activity types are
* ‘biking’
* ‘hiking’
* ‘running’
* ‘swimming’
* ‘walking’

Automatic coloring can still be disabled using the "Detect color from Strava bulk export" toggle in the UI.

closes #71