### PR TITLE
Fix parsing GPX/TCX with leading whitespace

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -11,7 +11,7 @@ import { parseSkizFile } from 'skiz-parser';
 
 function parseXML(xmlString) {
     const parser = new DOMParser();
-    const doc = parser.parseFromString(xmlString, 'text/xml');
+    const doc = parser.parseFromString(xmlString.trimStart(), 'text/xml');
 
     const parseError = doc.querySelector('parsererror');
     if (parseError) {


### PR DESCRIPTION
`DOMParser` is strict about this, and will fail to parse otherwise valid XML that has leading spaces.

Fixes #77